### PR TITLE
Build on Linux with extra error handling

### DIFF
--- a/MinecraftYoutube/src/main.cpp
+++ b/MinecraftYoutube/src/main.cpp
@@ -28,9 +28,18 @@ void GLAPIENTRY errorMessageCallback(
 	}
 }
 
+void glfwErrorCallback(int error, const char* description)
+{
+	g_logger_error("GLFW CALLBACK: **GLFW ERROR** Error: %d description: %s\n", error, description);
+}
+
 int main()
 {
-	glfwInit();
+	glfwSetErrorCallback(glfwErrorCallback);
+	if(!glfwInit()){
+		g_logger_error("GLFW failed to initialize");
+		return -1;
+	}
 
 	Window* window = Window::createWindow(windowWidth, windowHeight, windowTitle);
 	if (window == nullptr)

--- a/MinecraftYoutube/src/renderer/Shader.cpp
+++ b/MinecraftYoutube/src/renderer/Shader.cpp
@@ -18,6 +18,10 @@ namespace MinecraftClone
 		std::string shaderSourceCode = ReadFile(filepath);
 
 		GLenum shaderType = toGlShaderType(type);
+		if (shaderType == GL_INVALID_ENUM) {
+			g_logger_error("ShaderType is unknown");
+			return false;
+		}
 
 		// Create an empty shader handle
 		shaderId = glCreateShader(shaderType);
@@ -79,6 +83,7 @@ namespace MinecraftClone
 		case ShaderType::Fragment:
 			return GL_FRAGMENT_SHADER;
 		}
+		return GL_INVALID_ENUM;
 	}
 
 	static std::string ReadFile(const char* filepath)

--- a/premake5.lua
+++ b/premake5.lua
@@ -73,14 +73,42 @@ project "MinecraftYoutube"
             "_GLFW_WIN32",
             "_CRT_SECURE_NO_WARNINGS"
         }
+    filter "system:linux"
+        links { "dl", "pthread" }
+        systemversion "latest"
+
+        files {
+            "MinecraftYoutube/vendor/GLFW/src/x11_init.c",
+            "MinecraftYoutube/vendor/GLFW/src/linux_joystick.c",
+            "MinecraftYoutube/vendor/GLFW/src/x11_monitor.c",
+            "MinecraftYoutube/vendor/GLFW/src/posix_time.c",
+            "MinecraftYoutube/vendor/GLFW/src/posix_thread.c",
+            "MinecraftYoutube/vendor/GLFW/src/x11_window.c",
+            "MinecraftYoutube/vendor/GLFW/src/glx_context.c",
+            "MinecraftYoutube/vendor/GLFW/src/egl_context.c",
+            "MinecraftYoutube/vendor/GLFW/src/osmesa_context.c",
+            "MinecraftYoutube/vendor/GLFW/src/posix_module.c",
+            "MinecraftYoutube/vendor/GLFW/src/xkb_unicode.c",
+            "MinecraftYoutube/vendor/GLFW/src/x11_platform.h"
+        }
+
+        defines {
+            "_GLFW_X11"
+        }
+
+    filter { "system:windows", "configurations:Debug" }
+        buildoptions "/MTd"
+    filter { "system:linux", "configurations:Debug" }
+        buildoptions "-g"
 
     filter { "configurations:Debug" }
-        buildoptions "/MTd"
         runtime "Debug"
         symbols "on"
 
-    filter { "configurations:Release" }
+    filter { "system:windows", "configurations:Release" }
         buildoptions "/MT"
+
+    filter { "configurations:Release" }
         runtime "Release"
         optimize "on"
 


### PR DESCRIPTION
Build on Linux by expanding premake5.lua, add error handling which helped testing the building process.